### PR TITLE
Changed the structure of layers

### DIFF
--- a/dgplib/layers.py
+++ b/dgplib/layers.py
@@ -107,42 +107,55 @@ def find_weights(input_dim, output_dim, X):
 
     return W
 
-class InputLayer(Layer):
-    @defer_build()
-    def initialize_forward(self, X, Z):
-        """
-        Initialize Layer and Propagate values of inputs and inducing inputs
-        forward
-        """
-
+class InputMixin(object):
+    """
+    Mixin class for input layers. Implements a single method to compute the
+    value of the inputs and inducing inputs for the next layer.
+    """
+    def compute_inputs(self, X, Z):
         W = find_weights(self.input_dim, self.output_dim, X)
-
-        self.Z.assign(Z)
 
         Z_running = Z.copy().dot(W)
         X_running = X.copy().dot(W)
 
-        if isinstance(self.mean_function, Linear):
-            self.mean_function.A = W
-            self.mean_function.set_trainable(False)
+        return X_running, Z_running, W
 
-        return X_running, Z_running
+class HiddenMixin(object):
+    """
+    Mixin class for hidden layers. Implements a single method to compute the
+    value of the inputs and inducing inputs for the next layer.
+    """
+    def compute_inputs(self, X, Z):
+        W = find_weights(self.input_dim, self.output_dim, X)
 
+        Z_running = self.Z.value.copy().dot(W)
+        X_running = X.copy().dot(W)
 
-class HiddenLayer(Layer):
+        return X_running, Z_running, W
+
+class OutputMixin(object):
+    """
+    Mixin class for output layers. Does not implement any methods. Only used
+    for type checking.
+    """
+    def compute_inputs(self, X, Z):
+        W = find_weights(self.input_dim, self.output_dim, X)
+
+        Z_running = self.Z.value.copy().dot(W)
+        X_running = X.copy().dot(W)
+
+        return X_running, Z_running, W
+
+class InputLayer(Layer, InputMixin):
     @defer_build()
     def initialize_forward(self, X, Z):
         """
         Initialize Layer and Propagate values of inputs and inducing inputs
         forward
         """
-
-        W = find_weights(self.input_dim, self.output_dim, X)
-
         self.Z.assign(Z)
 
-        Z_running = self.Z.value.copy().dot(W)
-        X_running = X.copy().dot(W)
+        X_running, Z_running, W = self.compute_inputs(X, Z)
 
         if isinstance(self.mean_function, Linear):
             self.mean_function.A = W
@@ -150,7 +163,25 @@ class HiddenLayer(Layer):
 
         return X_running, Z_running
 
-class OutputLayer(Layer):
+
+class HiddenLayer(Layer, HiddenMixin):
+    @defer_build()
+    def initialize_forward(self, X, Z):
+        """
+        Initialize Layer and Propagate values of inputs and inducing inputs
+        forward
+        """
+        self.Z.assign(Z)
+
+        X_running, Z_running, W = self.compute_inputs(X, Z)
+
+        if isinstance(self.mean_function, Linear):
+            self.mean_function.A = W
+            self.mean_function.set_trainable(False)
+
+        return X_running, Z_running
+
+class OutputLayer(Layer, OutputMixin):
     @defer_build()
     def initialize_forward(self, X, Z):
         """


### PR DESCRIPTION
Changed the structure of `layers.py`.
Now the different types of layers (`InputLayer`, `OutputLayer` and `HiddenLayer`) inherit from a `Layer` object and a mixin specific to the type of layer. This was done to reduce boilerplate code and enable easier type checking. 